### PR TITLE
Chatwork株式会社は株式会社kubellへと社名変更

### DIFF
--- a/company-list/11_A-Z.md
+++ b/company-list/11_A-Z.md
@@ -6,18 +6,6 @@
 ## 株式会社CAM
 - [Lighthouseには映らないAccessibility | 株式会社CAM](https://cam-inc.co.jp/p/techblog/466554823458685993)
 
-## Chatwork株式会社
-- [ChatWorkはアクセシビリティに対応します | Chatworkブログ](https://blog-ja.chatwork.com/2017/04/chatwork_20.html)
-- [「UIデザイナーのスキルマップ」にアクセシビリティスキルを入れた話 - Chatwork Creator's Note](https://creators-note.chatwork.com/entry/2019/12/18/172314)
-- [a11y対応やってくぞい - Speaker Deck](https://speakerdeck.com/yukilabo/a11ydui-ying-yatutekuzoi)
-- [祝 🎉 アクセシビリティ改善チームができました！ - Chatwork Creator's Note](https://creators-note.chatwork.com/entry/2020/11/10/113000)
-- [「働く」を「権利」と定義したChatworkアクセシビリティ方針決定の裏側](https://cocoda.design/emim/p/p2705ac0df7cf)
-- [啓蒙は、丁寧に継続的に。アクセシビリティの社内推進とメンバーの巻き込み方](https://cocoda.design/emim/p/p5ef8dd28de53)
-- [「アクセシビリティに終わりはない」初手としてのWebサイトのアクセシビリティ対応](https://cocoda.design/emim/p/p76f8db5a17c4)
-- [一朝一夕にはいかない！だからアクセシビリティガイドラインの理解はERで磨く｜Chatwork Design｜note](https://note.com/chatworkdesign/n/n95a99c8ce41c)
-- [デザイナーが難解なガイドライン（WCAG）を乗り越える方法（提案）｜emim｜note](https://note.com/emiemihuimei/n/nf99a59b29029)
-- [アクセシビリティ方針と試験結果 | Chatwork株式会社](https://corp.chatwork.com/ja/accessibility/)
-
 ## 合同会社DMM.com
 - [「なんでもやってるDMM」を支えるアクセシビリティガイドライン - Speaker Deck](https://speakerdeck.com/miterashishohei/nandemoyatuterudmm-wozhi-eruakusesibiriteigaidorain)
 - [障がい者が「働き続けられる」ための工夫とその成果 - DMM inside](https://inside.dmm.com/entry/2022/2/17/bc-in-numbers)
@@ -47,6 +35,18 @@
 ## 株式会社KDDIウェブコミュニケーションズ
 - [ウェブアクセシビリティ方針 - 株式会社KDDIウェブコミュニケーションズ](https://www.kddi-webcommunications.co.jp/accessibility/)
 - [#3 神森 勉（KDDIウェブコミュニケーションズ）「誰もがウェブサイトを持つために…ウェブサイトビルダーができること」【GAAD Japan 2020】 - YouTube](https://www.youtube.com/watch?v=1LCb-7ju3_U)
+
+## 株式会社kubell
+- [ChatWorkはアクセシビリティに対応します | Chatworkブログ](https://blog-ja.chatwork.com/2017/04/chatwork_20.html)
+- [「UIデザイナーのスキルマップ」にアクセシビリティスキルを入れた話 - Chatwork Creator's Note](https://creators-note.chatwork.com/entry/2019/12/18/172314)
+- [a11y対応やってくぞい - Speaker Deck](https://speakerdeck.com/yukilabo/a11ydui-ying-yatutekuzoi)
+- [祝 🎉 アクセシビリティ改善チームができました！ - Chatwork Creator's Note](https://creators-note.chatwork.com/entry/2020/11/10/113000)
+- [「働く」を「権利」と定義したChatworkアクセシビリティ方針決定の裏側](https://cocoda.design/emim/p/p2705ac0df7cf)
+- [啓蒙は、丁寧に継続的に。アクセシビリティの社内推進とメンバーの巻き込み方](https://cocoda.design/emim/p/p5ef8dd28de53)
+- [「アクセシビリティに終わりはない」初手としてのWebサイトのアクセシビリティ対応](https://cocoda.design/emim/p/p76f8db5a17c4)
+- [一朝一夕にはいかない！だからアクセシビリティガイドラインの理解はERで磨く｜Chatwork Design｜note](https://note.com/chatworkdesign/n/n95a99c8ce41c)
+- [デザイナーが難解なガイドライン（WCAG）を乗り越える方法（提案）｜emim｜note](https://note.com/emiemihuimei/n/nf99a59b29029)
+- [アクセシビリティ方針と試験結果 | Chatwork株式会社](https://corp.chatwork.com/ja/accessibility/)
 
 ## 株式会社Kyash
 - [Jetpack Compose から始める、アクセシビリティ - Kyash Product Blog](https://blog.kyash.co/entry/2021/10/01/173000)


### PR DESCRIPTION
2024年7月1日から有効

関連：[Chatwork株式会社は株式会社kubellへと社名変更します｜山本 正喜 / Chatwork CEO](https://note.com/cwmasaki/n/n11aed08f8fc9)